### PR TITLE
use include function instead of get_template to fix inaccessible variables with template customization

### DIFF
--- a/inc/widget.php
+++ b/inc/widget.php
@@ -121,10 +121,12 @@ class Kebo_Twitter_Feed_Widget extends WP_Widget {
          */
         if ( 2 == $instance['style'] ) {
             
-            if ( '' != locate_template( 'views/kebo-twitter-slider.php' ) ) {
+            $slider_template_path = locate_template( 'views/kebo-twitter-slider.php' );
+            if ( '' != $slider_template_path ) {
                 
-                // yep, load the page template
-                get_template_part( 'views/kebo-twitter-slider' );
+                // yep, load the page template with the include function
+                // so the variables are accessible
+                include($slider_template_path);
                     
             } else {
                 
@@ -134,10 +136,12 @@ class Kebo_Twitter_Feed_Widget extends WP_Widget {
             
         } else {
             
-            if ( '' != locate_template( 'views/kebo-twitter-list.php' ) ) {
-                
-                // yep, load the page template
-                get_template_part( 'views/kebo-twitter-list' );
+            $list_template_path = locate_template( 'views/kebo-twitter-slider.php' );
+            if ( '' != $list_template_path ) {
+
+                // yep, load the page template with the include function
+                // so the variables are accessible
+                include($list_template_path);
                     
             } else {
                 

--- a/inc/widget.php
+++ b/inc/widget.php
@@ -136,7 +136,7 @@ class Kebo_Twitter_Feed_Widget extends WP_Widget {
             
         } else {
             
-            $list_template_path = locate_template( 'views/kebo-twitter-slider.php' );
+            $list_template_path = locate_template( 'views/kebo-twitter-list.php' );
             if ( '' != $list_template_path ) {
 
                 // yep, load the page template with the include function


### PR DESCRIPTION
While the widget currently searches for a custom template file in the theme folder (using `get_template` ), when it is found the custom template fails to render properly because the variables such as `$instance` are not available when the template is loaded via Wordpress'  `get_template_part` method.

This fix uses the `include` function instead, it is a solution based on from [kdev's blog](http://keithdevon.com/passing-variables-to-get_template_part-in-wordpress/) - this fix is tested and working with a custom template in the theme's `views/kebo-twitter-list.php` folder.
